### PR TITLE
Only catch Exception & subclasses

### DIFF
--- a/encore/events/event_manager.py
+++ b/encore/events/event_manager.py
@@ -339,7 +339,7 @@ class EventManager(BaseEventManager):
         for listener in listeners:
             try:
                 listener(evt)
-            except BaseException as e:
+            except Exception as e:
                 logger.warn('Exception {0} occurred in listener: {1} for '
                     'event: {2}:\n{3}'.format(e, listener, evt,
                                               traceback.format_exc()))


### PR DESCRIPTION
We should only ever catch Exception subclasses in this try: ... except
...; otherwise we will swallow important non-error Exceptions like
SystemExit and KeyboardInterrupt.
