### PR TITLE
ENH: EventManager: added a global event manager.

### DIFF
--- a/encore/events/api.py
+++ b/encore/events/api.py
@@ -10,3 +10,4 @@ from .abstract_event_manager import BaseEvent, BaseEventManager
 from .event_manager import EventManager
 from .progress_events import (ProgressEvent, ProgressStartEvent,
     ProgressStepEvent, ProgressEndEvent, ProgressManager)
+from .package_globals import get_event_manager, set_event_manager

--- a/encore/events/package_globals.py
+++ b/encore/events/package_globals.py
@@ -1,0 +1,40 @@
+#
+# Canopy product code
+#
+# (C) Copyright 2011 Enthought, Inc., Austin, TX
+# All right reserved.
+#
+# This file is confidential and NOT open source.  Do not distribute.
+#
+""" Module to hold global state, such as a global event manager.
+
+"""
+
+
+from .event_manager import EventManager
+
+_event_manager = None
+
+def get_event_manager():
+    """ Get the global event manager. """
+    global _event_manager
+    if _event_manager is None:
+        _event_manager = EventManager()
+    return _event_manager
+
+def set_event_manager(event_manager):
+    """ Set the global event manager.
+
+    Raises
+    ------
+    ValueError - If an event manager has already been set. This is to prevent
+        the loss of registered listeners which may be being used by others.
+
+    """
+    global _event_manager
+    if _event_manager is not None:
+        raise ValueError('Event manager has already been set.')
+    _event_manager = event_manager
+
+
+

--- a/encore/events/tests/test_event_manager.py
+++ b/encore/events/tests/test_event_manager.py
@@ -13,6 +13,9 @@ import threading
 
 # Local imports.
 from encore.events.event_manager import EventManager, BaseEvent
+from encore.events.api import (get_event_manager, set_event_manager,
+                               BaseEventManager)
+import encore.events.package_globals as package_globals
 
 class TestEventManager(unittest.TestCase):
     def setUp(self):
@@ -556,6 +559,18 @@ class TestEventManager(unittest.TestCase):
         self.assertEqual(calls, [2, 1])
         calls[:] = []
 
+    def test_global_event_manager(self):
+        """ Test if getting/setting global event manager works. """
+        evt_mgr = get_event_manager()
+        self.assertIsInstance(evt_mgr, BaseEventManager)
+
+        # Reset the global event_manager
+        package_globals._event_manager = None
+
+        set_event_manager(self.evt_mgr)
+        self.assertEqual(self.evt_mgr, get_event_manager())
+
+        self.assertRaises(ValueError, lambda: set_event_manager(evt_mgr))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is useful in many places where adding and additional argument
for event manager is cumbersome and adds unnecessary code bloat.
It is still possible to create other event manager instances, but
by default all components should be able to use the event manager
returned from `encore.events.api.get_event_manager()`
