### PR TITLE
Windows lockingfsstore ioerror

### DIFF
--- a/encore/storage/locking_filesystem_store.py
+++ b/encore/storage/locking_filesystem_store.py
@@ -127,6 +127,7 @@ def write_log(func, event='w'):
                 # FIXME: Assuming max line length is 1024
                 log_file.seek(max(0, end_pos-1024))
                 etext = log_file.read()
+                log_file.seek(0) # Needed on windows to be able to write.
                 text = etext.splitlines()[-1]
                 id = int(text.split()[0]) + 1
             else:


### PR DESCRIPTION
Workaround windows bug whereby ioerror is raised on writing to
a read file ( IOError: [Errorno 0] Error )
Thanks to Valery for finding the bug and the fix.
