### PR TITLE
Windows filelock fixes

### DIFF
--- a/encore/storage/locking_filesystem_store.py
+++ b/encore/storage/locking_filesystem_store.py
@@ -339,7 +339,7 @@ class LockingFileSystemStore(FileSystemStore):
     ##########################################################################
 
     def _get_lockfile_path(self, key):
-        return os.path.join(self._root, key + '.lock')
+        return os.path.join(self._root, key)
 
     @contextmanager
     def _locking(self, key, recurse=True, shared=False):


### PR DESCRIPTION
Windows locks files being read which prevents FileLock from being
released while someone else is checking the lock.
Also removed duplicate .lock extensions in lock files created by
LockingFileSystemStore.
