### PR TITLE
Heartbeat Event Generator

### DIFF
--- a/encore/events/api.py
+++ b/encore/events/api.py
@@ -10,4 +10,5 @@ from .abstract_event_manager import BaseEvent, BaseEventManager
 from .event_manager import EventManager
 from .progress_events import (ProgressEvent, ProgressStartEvent,
     ProgressStepEvent, ProgressEndEvent, ProgressManager)
+from .heartbeat import Heartbeat, HeartbeatEvent
 from .package_globals import get_event_manager, set_event_manager

--- a/encore/events/heartbeat.py
+++ b/encore/events/heartbeat.py
@@ -1,0 +1,60 @@
+#
+# (C) Copyright 2012 Enthought, Inc., Austin, TX
+# All right reserved.
+#
+# This file is open source software distributed according to the terms in
+# LICENSE.txt
+#
+
+import time
+import threading
+
+from .abstract_event_manager import BaseEvent
+from .package_globals import get_event_manager
+
+class HeartbeatEvent(BaseEvent):
+    """ Event which is emitted periodically
+    """
+    pass
+
+class Heartbeat(object):
+    """ Service which emits an event periodically
+    
+    Note that unless the event manager uses threaded dispatch, event listeners
+    which take longer than the interval to perform will result in a slower
+    heartbeat.  The heartbeat runs on its own thread, and as a result, any
+    listeners will also run on that thread.
+    
+    The heartbeat is only intended to be approximately accurate, and should not
+    be used for applications which require precise timing.
+    
+    """
+    
+    def __init__(self, interval=1/50., event_manager=None):
+        self.state = 'waiting'
+        self.interval = interval
+        self.frame_count = 0
+        self.event_manager = (event_manager if event_manager is not None
+            else get_event_manager())
+    
+    def run(self):
+        self.state = 'running'
+        while self.state in ['running', 'paused']:
+            if self.state == 'running':
+                t = time.time()
+                self.event_manager.emit(HeartbeatEvent(source=self, time=t,
+                    frame=self.frame_count, interval=self.interval))
+                self.frame_count += 1
+                # try to ensure regular heartbeat, but always sleep for at least 1ms
+                wait = max(t+self.interval-time.time(), 0.001)
+            else:
+                wait = self.interval
+            time.sleep(wait)
+        self.state = 'stopped'
+
+    def serve(self):
+        thread = threading.Thread(target=self.run)
+        thread.daemon = True
+        thread.start()
+    
+


### PR DESCRIPTION
Add a heartbeat event generator, which emits an event periodically.  Useful for driving pollers or other things which must happen periodically.  Timing is not precise, and if too much processing is done in the event listeners then the heartbeat will not keep up with the requested timing.
