### PR TITLE
RequestsURLValue constructor fails if session object doesn't have a config attribute

### DIFF
--- a/encore/storage/dynamic_url_store.py
+++ b/encore/storage/dynamic_url_store.py
@@ -20,7 +20,8 @@ class RequestsURLValue(Value):
     def __init__(self, session, base_url, key, url_format='{base}/{key}/{part}',
             parts=None):
         self._session = session
-        self._session.config['keep_alive'] = False
+        config = getattr(self._session, 'config', {})
+        config['keep_alive'] = False
         self._base_url = base_url
         self._key = key
         self._url_format = url_format


### PR DESCRIPTION
This made the key access from the dynamic URL store fail.
