### PR TITLE
BUG: Let session's keep_alive option be True

### DIFF
--- a/encore/storage/dynamic_url_store.py
+++ b/encore/storage/dynamic_url_store.py
@@ -20,7 +20,6 @@ class RequestsURLValue(Value):
     def __init__(self, session, base_url, key, url_format='{base}/{key}/{part}',
             parts=None):
         self._session = session
-        self._session.config['keep_alive'] = False
         self._base_url = base_url
         self._key = key
         self._url_format = url_format


### PR DESCRIPTION
This seems to speed up things, since existing connection is reused
when talking to the server multiple times.

Closes #39
