### PR TITLE
Merge ThreadPoolExecutor changes from Python 3.x that fix polling workers.

### DIFF
--- a/encore/concurrent/futures/enhanced_thread_pool_executor.py
+++ b/encore/concurrent/futures/enhanced_thread_pool_executor.py
@@ -19,9 +19,10 @@ changes:
     * 'map' works without iterating (bugs.python.org/issue11777).
     * Workers do not unnecessarily retain references to work items
       (bugs.python.org/issue16284).
+    * Workers do not use polling: http://bugs.python.org/issue11635
 
 The implementation is largely copied to avoid reliance on undocumented, private
-parts of the code. For example, '_thread_references' is needed to properly
+parts of the code. For example, '_threads_queues' is needed to properly
 manage threads in the ThreadPoolExecutor, but this is not guaranteed to exist
 in future implementations of concurrent.futures.thread.
 
@@ -52,30 +53,18 @@ from concurrent.futures import _base
 # workers to exit when their work queues are empty and then waits until the
 # threads finish.
 
-_thread_references = set()
+_threads_queues = weakref.WeakKeyDictionary()
 _shutdown = False
 
 
 def _python_exit():
     global _shutdown
     _shutdown = True
-    for thread_reference in set(_thread_references):
-        thread = thread_reference()
-        if thread is not None:
-            thread.join()
-
-
-def _remove_dead_thread_references():
-    """Remove inactive threads from _thread_references.
-
-    Should be called periodically to prevent memory leaks in scenarios such as:
-    >>> while True:
-    ...    t = ThreadPoolExecutor(max_workers=5)
-    ...    t.map(int, ['1', '2', '3', '4', '5'])
-    """
-    for thread_reference in set(_thread_references):
-        if thread_reference() is None:
-            _thread_references.discard(thread_reference)
+    items = list(_threads_queues.items())
+    for t, q in items:
+        q.put(None)
+    for t, q in items:
+        t.join()
 
 atexit.register(_python_exit)
 
@@ -111,21 +100,22 @@ def _worker(executor_reference, work_queue, initialize=None,
 
     try:
         while True:
-            try:
-                work_item = work_queue.get(block=True, timeout=0.1)
-            except queue.Empty:
-                executor = executor_reference()
-                # Exit if:
-                #   - The interpreter is shutting down OR
-                #   - The executor that owns the worker has been collected OR
-                #   - The executor that owns the worker has been shutdown.
-                if _shutdown or executor is None or executor._shutdown:
-                    break
-                del executor
-            else:
+            work_item = work_queue.get(block=True)
+            if work_item is not None:
                 work_item.run()
                 # Delete references to object. See issue16284
                 del work_item
+                continue
+            executor = executor_reference()
+            # Exit if:
+            #   - The interpreter is shutting down OR
+            #   - The executor that owns the worker has been collected OR
+            #   - The executor that owns the worker has been shutdown.
+            if _shutdown or executor is None or executor._shutdown:
+                # Notify other workers.
+                work_queue.put(None)
+                return
+            del executor
     except BaseException:
         _base.LOGGER.critical('Exception in worker', exc_info=True)
     finally:
@@ -157,8 +147,6 @@ class EnhancedThreadPoolExecutor(_base.Executor):
                 class name will be used.
 
         """
-        _remove_dead_thread_references()
-
         self._max_workers = max_workers
         self._work_queue = queue.Queue()
         self._threads = set()
@@ -185,21 +173,28 @@ class EnhancedThreadPoolExecutor(_base.Executor):
     submit.__doc__ = _base.Executor.submit.__doc__
 
     def _adjust_thread_count(self):
+        # When the executor gets lost, the weakref callback will wake up
+        # the worker threads.
+        def weakref_cb(_, q=self._work_queue):
+            q.put(None)
+
         if len(self._threads) < self._max_workers:
             thread_name = "{0}Worker-{1}".format(self.name,
                                                  next(self._thread_counter))
             t = threading.Thread(target=_worker, name=thread_name,
-                                 args=(weakref.ref(self), self._work_queue,
+                                 args=(weakref.ref(self, weakref_cb),
+                                       self._work_queue,
                                        self._initializer,
                                        self._uninitializer))
             t.daemon = True
             t.start()
             self._threads.add(t)
-            _thread_references.add(weakref.ref(t))
+            _threads_queues[t] = self._work_queue
 
     def shutdown(self, wait=True):
         with self._shutdown_lock:
             self._shutdown = True
+            self._work_queue.put(None)
         if wait:
             for t in self._threads:
                 t.join()


### PR DESCRIPTION
This PR brings in changes from upstream Python 3 (mainly from http://bugs.python.org/issue11777) that ensure that worker threads don't poll.  This may bring some performance improvements when making heavy use of the executor machinery.
