### PR TITLE
use DynamicURLStore.parts consistently

### DIFF
--- a/encore/storage/dynamic_url_store.py
+++ b/encore/storage/dynamic_url_store.py
@@ -131,7 +131,7 @@ class RequestsURLValue(Value):
 class DynamicURLStore(AbstractAuthorizingStore):
 
     def __init__(self, base_url, query_url, url_format='{base}/{key}/{part}',
-            parts=DEFAULT_PARTS):
+                 parts=DEFAULT_PARTS):
         super(AbstractAuthorizingStore, self).__init__()
         self.base_url = base_url
         self.query_url = query_url

--- a/encore/storage/tests/dynamic_url_store_test.py
+++ b/encore/storage/tests/dynamic_url_store_test.py
@@ -1,0 +1,17 @@
+import os
+from tempfile import mkdtemp
+from unittest import TestCase
+from ..dynamic_url_store import DynamicURLStore
+
+class DynamicURLStoreTest(TestCase):
+    ''' TODO: This should be a full test suite. '''
+    def setUp(self):
+        self.store = DynamicURLStore('http://localhost',
+                                     None,
+                                     parts={'data': 'd',
+                                            'metadata': 'm',
+                                            'permissions': 'p'})
+
+    def test_parts(self):
+        url = self.store._url('key', 'data')
+        self.assertEqual(url, 'http://localhost/key/d')

--- a/encore/storage/tests/static_url_store_test.py
+++ b/encore/storage/tests/static_url_store_test.py
@@ -21,22 +21,22 @@ from ..static_url_store import StaticURLStore
 
 class StaticURLStoreReadTest(abstract_test.AbstractStoreReadTest):
     resolution = 'second'
-    
+
     def setUp(self):
         """ Set up a data store for the test case
-        
+
         The store should have:
-            
+
             * a key 'test1' with a file-like data object containing the
               bytes 'test2\n' and metadata {'a_str': 'test3', 'an_int': 1,
               'a_float': 2.0, 'a_bool': True, 'a_list': ['one', 'two', 'three'],
               'a_dict': {'one': 1, 'two': 2, 'three': 3}}
-            
+
             * keys 'key0' through 'key9' with values 'value0' through 'value9'
-              in filelike objects, and metadata {'query_test1': 'value', 
+              in filelike objects, and metadata {'query_test1': 'value',
               'query_test2': 0 through 9, 'optional': True for even,
-              not present for odd} 
-        
+              not present for odd}
+
         and set into 'self.store'.
         """
         super(StaticURLStoreReadTest, self).setUp()
@@ -60,16 +60,16 @@ class StaticURLStoreReadTest(abstract_test.AbstractStoreReadTest):
             if i % 2 == 0:
                 metadata['key%d'%i]['optional'] = True
         self._write_index('index.json', json.dumps(metadata))
-        
+
         self._running = True
-        
+
         self._set_up_server()
         time.sleep(1)
 
 
         self.store = StaticURLStore(self._get_base_url(), 'data/', 'index.json')
         self.store.connect()
-    
+
     def tearDown(self):
         self.store.disconnect()
         self._running = False
@@ -91,11 +91,11 @@ class StaticURLStoreReadTest(abstract_test.AbstractStoreReadTest):
 
     def _get_base_url(self):
         return 'file://'+self.path+'/'
-            
+
     def _write_data(self, filename, data):
         with file(os.path.join(self.path, 'data', filename), 'wb') as fp:
             fp.write(data)
-    
+
     def _write_index(self, filename, data):
         with file(os.path.join(self.path, filename), 'wb') as fp:
             fp.write(data)
@@ -104,15 +104,15 @@ class ThreadedHTTPServer(SocketServer.ThreadingMixIn, HTTPServer):
     pass
 
 class StaticURLStoreHTTPReadTest(StaticURLStoreReadTest):
-    
+
     def _get_base_url(self):
         return 'http://localhost:%s/' % self.port
- 
+
     def _set_up_server(self):
         self.port = 8080
         self._oldwd = os.getcwd()
         os.chdir(self.path)
-        
+
         self.server = ThreadedHTTPServer(('localhost', self.port), SimpleHTTPRequestHandler)
         self.server_thread = threading.Thread(target=self.server.serve_forever, args=(0.1,))
         self.server_thread.daemon = True
@@ -122,5 +122,3 @@ class StaticURLStoreHTTPReadTest(StaticURLStoreReadTest):
         self.server.shutdown()
         del self.server
         os.chdir(self._oldwd)
-
-


### PR DESCRIPTION
We were using the self.parts mapping sometimes, but not others.  This fixes that.
