### PR TITLE
Adding concurrent futures copyright for EnhancedThreadPoolExecutor to LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -46,3 +46,9 @@ software distributed under the License is distributed on an
 either express or implied. 
 See the License for the specific language governing permissions 
 and limitations under the License. 
+
+concurrent.futures.enhanced_thread_pool_executor
+------------------------------------------------
+
+Copyright 2009 Brian Quinlan. All Rights Reserved.
+Licensed to PSF under a Contributor Agreement.


### PR DESCRIPTION
I'm making the copyright statement that is already in concurrent.futures.enhanced_thread_pool_executor more apparent by adding it to `LICENSE.txt`. I am not certain we are license compliant in any case. The code in question has been edited by us. Does anyone (@rkern, @itziakos, @sjagoe) know the proper license display/extension for PSF-contributed code? 
