### PR TITLE
Added delayed asynchronizer, enforcing an interval between submitted operations

### DIFF
--- a/encore/concurrent/futures/delayed_asynchronizer.py
+++ b/encore/concurrent/futures/delayed_asynchronizer.py
@@ -58,8 +58,7 @@ class DelayedAsynchronizer(Asynchronizer):
             factory must accept two arguments: The interval in seconds
             and a callback to be executed on timeout.  The returned
             timer must have ``start()`` method to start the timer and a
-            ``cancel()`` method to cancell the current timer at
-            shutdown.
+            ``cancel()`` method to cancel the current timer at shutdown.
 
         Notes
         -----

--- a/encore/concurrent/futures/delayed_asynchronizer.py
+++ b/encore/concurrent/futures/delayed_asynchronizer.py
@@ -1,0 +1,120 @@
+#
+# (C) Copyright 2012-13 Enthought, Inc., Austin, TX
+# All right reserved.
+#
+# This file is open source software distributed according to the terms in
+# LICENSE.txt
+#
+import logging
+import threading
+
+from .asynchronizer import Asynchronizer
+
+logger = logging.getLogger(__name__)
+
+
+class DelayedAsynchronizer(Asynchronizer):
+    """A 'forgetful' scheduling of operations which enforces a delay
+    between submitted operations.
+
+    The Asynchronizer executes at most a single operation at a
+    time. Requests to `submit` a new operation while an operation is
+    executed are stored for future execution, with each new submission
+    overwriting the prior.  When a running operation completes, a timer
+    is started to schedule the most recent submission (if one exists) to
+    be executed. Therefore, operations submitted between the previous
+    and current execution are discarded.  The last operation submitted
+    is guaranteed to eventually be executed unless the delayed
+    asynchronizer is shut down before the timer completes.
+
+    """
+
+    def __init__(self, executor, interval, name=None, callback=None,
+                 timer_factory=None):
+        """Initialize the Asynchronizer.
+
+        Parameters
+        ----------
+        executor : concurrent.features.Executor
+            The executor to use for the jobs.
+
+        interval : float
+            Interval between operations in seconds.
+
+        name : string, optional
+            The name of the Scheduler to be identified in the logs.
+
+        callback : callable, optional
+            If a callable `callback` is provided, it will be called whenever an
+            execution completes.  The callback must accept as its only argument
+            the Future that encapsulates the job. (The Future objects used by
+            the scheduler are otherwise private.) Exceptions raised within the
+            callback will be logged and suppressed.  See the
+            `concurrent.futures` documentation for more information about
+            Future callbacks.
+
+        timer_factory : callable, optional
+            Returns a suitable timer configured with the interval.  The
+            factory must accept two arguments: The interval in seconds
+            and a callback to be executed on timeout.  The returned
+            timer must have ``start()`` method to start the timer and a
+            ``cancel()`` method to cancell the current timer at
+            shutdown.
+
+        Notes
+        -----
+        Any exception that occurs are logged. Exceptions in the user-supplied
+        callback will mask exceptions in the future, which is expected when
+        working with future callbacks.
+
+        """
+        super(DelayedAsynchronizer, self).__init__(
+            executor, name=name, callback=callback)
+        if timer_factory is None:
+            timer_factory = threading.Timer
+        self._timer_factory = timer_factory
+        self._timer = None
+        self._interval = interval
+
+    def _operation_completion_callback(self, future):
+        """
+        Called on completion of an operation.
+
+        """
+        try:
+            if self._callback is not None:
+                self._callback(future)
+            future.result()
+        except Exception as e:
+            exc_type = type(e)
+            logger.exception(
+                "{0} occurred in submitted {1} job.".format(
+                    exc_type.__name__,
+                    self.name,
+                )
+            )
+            logger.error('Actual error:\n{}'.format(future.traceback()))
+
+        with self._state_lock:
+            self._timer = self._timer_factory(
+                self._interval, self._timer_callback)
+            self._timer.start()
+
+    def _timer_callback(self):
+        with self._state_lock:
+            self._future = None
+            self._schedule_new()
+            self._state_lock.notify_all()
+
+    def _prevent_new_operations(self):
+        """
+        Prevent any new operations from being scheduled.
+
+        Attempts to schedule any operation after this call will result
+        in a RuntimeError.
+
+        """
+        with self._state_lock:
+            self._shutdown = True
+            if self._timer is not None:
+                self._timer.cancel()

--- a/encore/concurrent/futures/tests/test_delayed_asynchronizer.py
+++ b/encore/concurrent/futures/tests/test_delayed_asynchronizer.py
@@ -1,0 +1,280 @@
+#
+# (C) Copyright 2013 Enthought, Inc., Austin, TX
+# All right reserved.
+#
+# This file is open source software distributed according to the terms in
+# LICENSE.txt
+#
+import contextlib
+import logging
+import operator
+import time
+import unittest
+
+from encore.concurrent.futures.delayed_asynchronizer import (
+    DelayedAsynchronizer)
+from encore.concurrent.futures.enhanced_thread_pool_executor import (
+    EnhancedThreadPoolExecutor)
+
+
+def _worker(data, value):
+    data.append(value)
+    return value
+
+
+class TestHandler(logging.Handler):
+    """
+    Simple logging handler that just accumulates and stores records.
+
+    """
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+@contextlib.contextmanager
+def loghandler(logger_name):
+    """
+    Log errors from a call and yield the handler.
+
+    """
+    handler = TestHandler()
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.DEBUG)
+    old_propagate_value = logger.propagate
+    logger.propagate = False
+    logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        logger.removeHandler(handler)
+        logger.propagate = old_propagate_value
+
+
+class _TestException(Exception):
+    pass
+
+
+class TestAsynchronizer(unittest.TestCase):
+
+    def setUp(self):
+        self.executor = EnhancedThreadPoolExecutor(
+            name='TestAsynchronizerExecutor',
+            max_workers=1)
+        self.asynchronizer = DelayedAsynchronizer(
+            name='TestAsynchronizer',
+            executor=self.executor,
+            interval=0.5,
+        )
+
+    def tearDown(self):
+        self.asynchronizer.shutdown()
+        del self.asynchronizer
+        self.executor.shutdown()
+        del self.executor
+
+    def test_events_collapsed(self):
+        numbers = []
+        self.asynchronizer.submit(_worker, numbers, 1)
+        self.asynchronizer.submit(_worker, numbers, 2)
+        self.asynchronizer.submit(_worker, numbers, 3)
+        self.asynchronizer.submit(_worker, numbers, 4)
+        self.asynchronizer.submit(_worker, numbers, 5)
+        self.asynchronizer.submit(_worker, numbers, 6)
+        self.asynchronizer.submit(_worker, numbers, 7)
+        self.asynchronizer.submit(_worker, numbers, 8)
+        self.asynchronizer.submit(_worker, numbers, 9)
+        self.asynchronizer.submit(_worker, numbers, 10)
+        self.asynchronizer.wait()
+        self.assertEqual(len(numbers), 2)
+        self.assertEqual(numbers[0], 1)
+        self.assertEqual(numbers[1], 10)
+
+    def test_events_delayed(self):
+        times = []
+        def _worker(_list):
+            _list.append(time.time())
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.wait()
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.wait()
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.submit(_worker, times)
+        self.asynchronizer.wait()
+        self.assertEqual(len(times), 6)
+        differences = [second - first
+                       for first, second in zip(times[:-1], times[1:])]
+        for difference in differences:
+            self.assertGreaterEqual(difference, 0.5)
+
+    def test_callback(self):
+        # Make a callback that repeats the insertion into another queue.
+        callback_numbers = []
+
+        def _callback(future):
+            value = future.result()
+            callback_numbers.append(value)
+
+        asynchronizer = DelayedAsynchronizer(
+            name='TestCallbackAsynchronizer',
+            executor=self.executor,
+            interval=0.25,
+            callback=_callback,
+        )
+
+        numbers = []
+        asynchronizer.submit(_worker, numbers, 1)
+        asynchronizer.submit(_worker, numbers, 2)
+        asynchronizer.submit(_worker, numbers, 3)
+        asynchronizer.submit(_worker, numbers, 4)
+        asynchronizer.submit(_worker, numbers, 5)
+        asynchronizer.submit(_worker, numbers, 6)
+        asynchronizer.submit(_worker, numbers, 7)
+        asynchronizer.submit(_worker, numbers, 8)
+        asynchronizer.submit(_worker, numbers, 9)
+        asynchronizer.submit(_worker, numbers, 10)
+        asynchronizer.wait()
+        self.assertEqual(len(numbers), 2)
+        self.assertEqual(numbers[0], 1)
+        self.assertEqual(numbers[1], 10)
+        self.assertEqual(len(callback_numbers), 2)
+        self.assertEqual(callback_numbers[0], 1)
+        self.assertEqual(callback_numbers[1], 10)
+        asynchronizer.shutdown()
+
+    def test_asynchronizer_name(self):
+        asynchronizer = DelayedAsynchronizer(
+            executor=self.executor,
+            name="Will",
+            interval=0.25,
+        )
+        self.assertEqual(asynchronizer.name, "Will")
+        self.assertEqual(
+            asynchronizer._executor.name,
+            'TestAsynchronizerExecutor')
+
+    def test_submit_after_shutdown(self):
+        self.asynchronizer.shutdown()
+        with self.assertRaises(RuntimeError):
+            self.asynchronizer.submit(lambda: None)
+
+    def test_submit_bad_job(self):
+        """
+        Submission of a job that causes an exception should succeed,
+        but we should get a logged exception as a result.
+
+        """
+        logger_name = 'encore.concurrent.futures.delayed_asynchronizer'
+        with loghandler(logger_name) as handler:
+            self.asynchronizer.submit(operator.div, 1, 0)
+            self.asynchronizer.wait()
+
+        # We log two messages for each failure. The actual traceback
+        # from the worker, and the exception of where it occurred
+        # (i.e. where the result was accessed)
+        self.assertEqual(len(handler.records), 2)
+        record = handler.records[0]
+        self.assertIsNotNone(record.exc_info)
+        exc_type, exc_value, exc_tb = record.exc_info
+        self.assertIs(exc_type, ZeroDivisionError)
+
+    def test_submit_bad_job_with_callback(self):
+        """
+        Submission of a job that causes an exception should succeed,
+        even with a (good) callback, but we should get a logged
+        exception as a result.
+
+        """
+
+        def _callback(future):
+            future.result()
+
+        asynchronizer = DelayedAsynchronizer(
+            name='TestCallbackExceptionAsynchronizer',
+            executor=self.executor,
+            interval=0.25,
+            callback=_callback,
+        )
+
+        # Submit a bad job
+        logger_name = 'encore.concurrent.futures.delayed_asynchronizer'
+        with loghandler(logger_name) as handler:
+            asynchronizer.submit(operator.div, 1, 0)
+            asynchronizer.wait()
+
+        # We log two messages for each failure. The actual traceback
+        # from the worker, and the exception of where it occurred
+        # (i.e. where the result was accessed)
+        self.assertEqual(len(handler.records), 2)
+        record = handler.records[0]
+        self.assertIsNotNone(record.exc_info)
+        exc_type, exc_value, exc_tb = record.exc_info
+        self.assertIs(exc_type, ZeroDivisionError)
+
+        asynchronizer.shutdown()
+
+    def test_submit_job_with_raising_callback(self):
+        """
+        Submission of a job with a raising callback should detect
+        the exception in the callback.
+
+        """
+
+        def _callback(future):
+            raise _TestException('Failing callback')
+
+        asynchronizer = DelayedAsynchronizer(
+            name='TestCallbackExceptionAsynchronizer',
+            executor=self.executor,
+            interval=0.25,
+            callback=_callback,
+        )
+
+        # Submit a good job
+        logger_name = 'encore.concurrent.futures.delayed_asynchronizer'
+        with loghandler(logger_name) as handler:
+            asynchronizer.submit(operator.add, 1, 0)
+            asynchronizer.wait()
+
+        # We log two messages for each failure. The actual traceback
+        # from the worker, and the exception of where it occurred
+        # (i.e. where the result was accessed)
+        self.assertEqual(len(handler.records), 2)
+        record = handler.records[0]
+        self.assertIsNotNone(record.exc_info)
+        exc_type, exc_value, exc_tb = record.exc_info
+        self.assertIs(exc_type, _TestException)
+
+        # Submit a bad job
+        with loghandler(logger_name) as handler:
+            asynchronizer.submit(operator.div, 1, 0)
+            asynchronizer.wait()
+
+        # We log two messages for each failure. The actual traceback
+        # from the worker, and the exception of where it occurred
+        # (i.e. where the result was accessed)
+        self.assertEqual(len(handler.records), 2)
+        record = handler.records[0]
+        self.assertIsNotNone(record.exc_info)
+        exc_type, exc_value, exc_tb = record.exc_info
+        self.assertIs(exc_type, _TestException)
+
+        asynchronizer.shutdown()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The rationale for this is that I have a trait handler that will continually trigger tasks while it is receiving live updates. The regular `Asynchronizer` does not fit my case as the submitted tasks will still use all available CPU time, even through an `Asynchronizer`. By enforcing a delay between updates, the task will be able to yield to other parts of the application.
