### PR TITLE
Explicitly disconnect sqlite connection when disconnecting store

### DIFF
--- a/encore/storage/tests/sqlite_store_test.py
+++ b/encore/storage/tests/sqlite_store_test.py
@@ -15,30 +15,30 @@ import encore.storage.tests.abstract_test as abstract_test
 from ..sqlite_store import SqliteStore
 
 class SqliteStoreReadTest(abstract_test.AbstractStoreReadTest):
-    
+
     def setUp(self):
         """ Set up a data store for the test case
-        
+
         The store should have:
-            
+
             * a key 'test1' with a file-like data object containing the
               bytes 'test2\n' and metadata {'a_str': 'test3', 'an_int': 1,
               'a_float': 2.0, 'a_bool': True, 'a_list': ['one', 'two', 'three'],
               'a_dict': {'one': 1, 'two': 2, 'three': 3}}
-            
+
             * keys 'key0' through 'key9' with values 'value0' through 'value9'
-              in filelike objects, and metadata {'query_test1': 'value', 
+              in filelike objects, and metadata {'query_test1': 'value',
               'query_test2': 0 through 9, 'optional': True for even,
-              not present for odd} 
-        
+              not present for odd}
+
         and set into 'self.store'.
         """
         super(SqliteStoreReadTest, self).setUp()
         self.path = mkdtemp()
         self.db_file = os.path.join(self.path, 'db.sqlite')
-        
+
         connection = sqlite3.connect(self.db_file)
-        
+
         connection.execute("""
             create table store (
                 key text primary key,
@@ -48,7 +48,7 @@ class SqliteStoreReadTest(abstract_test.AbstractStoreReadTest):
                 data blob
             )
             """)
-        
+
         t = time.time()
         connection.execute("""insert into store values (?, ?, ?, ?, ?)""", (
             b'test1',
@@ -69,39 +69,41 @@ class SqliteStoreReadTest(abstract_test.AbstractStoreReadTest):
                 metadata['optional'] = True
             connection.execute("""insert into store values (?, ?, ?, ?, ?)""", (key, metadata, t, t, data))
         connection.commit()
-        
+        connection.close()
+
         connection = None
-        
+
         self.store = SqliteStore(self.db_file, 'store')
         self.store.connect()
-    
+
     def tearDown(self):
+        self.store.disconnect()
         rmtree(self.path)
 
 
 class SqliteStoreWriteTest(abstract_test.AbstractStoreWriteTest):
-    
+
     def setUp(self):
         """ Set up a data store for the test case
-        
+
         The store should have:
-            
+
             * a key 'test1' with a file-like data object containing the
               bytes 'test2\n' and metadata {'a_str': 'test3', 'an_int': 1,
               'a_float': 2.0, 'a_bool': True, 'a_list': ['one', 'two', 'three'],
               'a_dict': {'one': 1, 'two': 2, 'three': 3}}
-             
+
             * a series of keys 'existing_key0' through 'existing_key9' with
               data containing 'existing_value0' throigh 'existing_value9' and
               metadata {'meta': True, 'meta1': 0} through {'meta': True, 'meta1': -9}
-       
+
         and set into 'self.store'.
         """
         self.path = mkdtemp()
         self.db_file = os.path.join(self.path, 'db.sqlite')
-        
+
         connection = sqlite3.connect(self.db_file)
-        
+
         connection.execute("""
             create table store (
                 key text primary key,
@@ -111,7 +113,7 @@ class SqliteStoreWriteTest(abstract_test.AbstractStoreWriteTest):
                 data blob
             )
             """)
-        
+
         t = time.time()
         connection.execute("""insert into store values (?, ?, ?, ?, ?)""", (
             b'test1',
@@ -130,7 +132,8 @@ class SqliteStoreWriteTest(abstract_test.AbstractStoreWriteTest):
             metadata = {'meta': True, 'meta1': -i}
             connection.execute("""insert into store values (?, ?, ?, ?, ?)""", (key, metadata, t, t, data))
         connection.commit()
-        
+        connection.close()
+
         connection = None
 
         self.store = SqliteStore(self.db_file, 'store')


### PR DESCRIPTION
Also explicitly call disconnect in the tear-down of the sqlite tests.

This was causing problems with windows because it couldn't delete the database file during teardown of the tests.
