### PR TITLE
Added os.path.normpath for Windows.

### DIFF
--- a/encore/storage/filesystem_store.py
+++ b/encore/storage/filesystem_store.py
@@ -525,4 +525,3 @@ class FileSystemStore(AbstractStore):
             os.utime(path, None)
         else:
             open(path, 'a').close()
-   


### PR DESCRIPTION
This PR corrects the `_get_metadata_path` and `_get_data_path` to normalize the path, so that when run on Windows, a mixture of path types does not result in an invalid filename.
