### PR TITLE
Refuse HTTP compression for DynamicURLValues.

### DIFF
--- a/encore/storage/dynamic_url_store.py
+++ b/encore/storage/dynamic_url_store.py
@@ -9,7 +9,6 @@
 import json
 import urllib
 import rfc822
-import gzip
 
 import requests
 


### PR DESCRIPTION
We were using Requests defaults, but `response.raw` wasn't applying any encoding, so if the server gae us gzipped data, we were getting gzipped data.

This PR adds an empty "Accepts-Encoding" header to the request, so we will no longer get gzipped data from correctly written HTTP servers. 
