### PR TITLE
Fix auth errors

### DIFF
--- a/encore/storage/dynamic_url_store.py
+++ b/encore/storage/dynamic_url_store.py
@@ -154,7 +154,7 @@ class DynamicURLStore(AbstractAuthorizingStore):
     def _validate_response(self, response, key):
         if response.status_code == 404:
             raise KeyError(key)
-        elif response.status_code == 403:
+        elif response.status_code == 403 or response.status_code == 401:
             raise AuthorizationError(key)
         response.raise_for_status()
 


### PR DESCRIPTION
Certain websites return 401 instead of 403 if a key is not accessible by a user.  Handle that case.
