### PR TITLE
Faster DynamicURLStore get_data

### DIFF
--- a/encore/storage/dynamic_url_store.py
+++ b/encore/storage/dynamic_url_store.py
@@ -206,12 +206,12 @@ class DynamicURLStore(AbstractAuthorizingStore):
     def get_data(self, key):
         headers = {'Accept-Encoding': ''}
         if _requests_version == '0':
-            response = self._session.get(self._url('data'),
+            response = self._session.get(self._url(key, 'data'),
                 prefetch=False, headers=headers)
         else:
-            response = self._session.get(self._url('data'),
+            response = self._session.get(self._url(key, 'data'),
                 stream=True, headers=headers)
-        self._validate_response(response)
+        self._validate_response(response, key)
         return response.raw
     get_data.__doc__ = AbstractAuthorizingStore.get_data.__doc__
 


### PR DESCRIPTION
Download the data directly from the URL rather than via a Value object, which avoids an extra HEAD call.
