### PR TITLE
Ignore but accept all keyword arguments

### DIFF
--- a/encore/concurrent/futures/synchronous.py
+++ b/encore/concurrent/futures/synchronous.py
@@ -35,7 +35,7 @@ class SynchronousExecutor(Executor):
 
     """
    
-    def __init__(self):
+    def __init__(self, **_):
         """ Initializes a new SynchronousExecutor instance."""
         self._shutdown = False
 


### PR DESCRIPTION
This mimics what [ThreadPoolExecutor uses](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)