### PR TITLE
Python 3 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
-  - 2.7
+  - 3.6
 install:
-  - pip install coverage requests futures sphinx
+  - pip install coverage requests sphinx
   - python setup.py install
 script:
-  - nosetests --with-coverage --cover-package=encore
+  - nosetests
   - make --directory docs html
 notifications:
   email:

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ can subscribe to events based on Event type or by filtering on event attributes.
 include UI components listening to low-level progress notifications and change notification for
 distributed resources.
 
-*Storage:* Abstract base classes and concrete implementations of a basic key-value storage API.  
+*Storage:* Abstract base classes and concrete implementations of a basic key-value storage API.
 The API is intended to be general purpose enough to support a variety of local and remote storage
 systems.
 
@@ -24,15 +24,13 @@ systems.
 
 Prerequisites
 -------------
-* Python >= 2.6 (not Python 3)
+* Python >= 3.6
 
 * Sphinx, graphviz, pydot (documentation build)
 
 * Some optional modules have dependencies on:
 
   - Requests (http://docs.python-requests.org/en/latest/)
-
-  - Futures (https://code.google.com/p/pythonfutures/)
 
 Build Status
 ------------

--- a/docs/source/concurrent/index.rst
+++ b/docs/source/concurrent/index.rst
@@ -3,8 +3,8 @@ Concurrent Package
 ==================
 
 The :py:mod:`encore.concurrent.futures` package provides an enhanced
-version of the ``concurrent.futures`` package for Python 2.7 with some
-useful experimental additions.
+version of the ``concurrent.futures`` package with some useful experimental
+additions.
 
 Contents
 --------

--- a/docs/source/storage/usage.rst
+++ b/docs/source/storage/usage.rst
@@ -18,7 +18,7 @@ HTTP Authentication::
 
     from encore.events.api import EventManager
     from encore.storage.static_url_store import StaticURLStore
-    
+
     event_manager = EventManager()
     store = StaticURLStore(event_manager, 'http://localhost:8080/', 'data', 'index.json')
     store.connect(credentials={'username': 'alibaba', password: 'Open Sesame'})
@@ -37,11 +37,11 @@ methods::
     value = store.get('my_document')
     datastream = value.data
     metadata = value.metadata
-    
+
 In this case datastream is a file-like object that streams bytes::
 
     data = datastream.read()
-    print data
+    print(data)
 
 More likely you will have used some sort of serialization format like XML, JSON
 or YAML to store your data in the document, so instead you can do::
@@ -66,10 +66,10 @@ The metadata stores auxilliary information about the data that is stored in the
 key.  It is a dictionary of reasonably serializable values (frequently it will
 serialize to JSON or similar format)::
 
-    print 'Document title:', metadata['title']
-    print 'Document author:', metadata['author']
-    print 'Document encoding:', metadata['encoding']
-    
+    print('Document title:', metadata['title'])
+    print('Document author:', metadata['author'])
+    print('Document encoding:', metadata['encoding'])
+
     # checksum
     import hashlib
     assert hashlib.sha1(document.read()).digest() == metadata['sha1']
@@ -106,7 +106,7 @@ key-value store API gives a simple query mechanism that permits this sort of
 matching::
 
     for key, metadata in store.query(author='alibaba', organization='40 Thieves'):
-        print key, ':', metadata['title']
+        print(key, ':', metadata['title'])
 
 This will print the key and title of all documents which have an ``author`` key
 with value ``'alibaba'`` and an ``organization`` key with value ``'40 Thieves'``.
@@ -118,19 +118,19 @@ If all the user is concerned with is which keys match, there is an alternative
 method :py:meth:`~.AbstractReadOnlyStore.query_keys`::
 
     for key in store.query_keys(author='alibaba', organization='40 Thieves'):
-        print key
+        print(key)
 
 To iterate over all the keys in a store, you can simply call :py:meth:`~.AbstractReadOnlyStore.query_keys`
 with no arguments::
 
     for key in store.query_keys():
-        print key
+        print(key)
 
 Finally, as a useful utility, you can use glob-style matching on the keys using
 the :py:meth:`~.AbstractReadOnlyStore.glob` method::
 
     for key in store.glob('*.jpg'):
-        print key
+        print(key)
 
 Writing
 -------
@@ -141,7 +141,7 @@ file-like object with a :py:meth:`~.Filelike.read` method that can do buffering,
 dictionary of metadata as arguments::
 
     from cStringIO import StringIO
-    
+
     data = StringIO("Hello World")
     metadata = {'title': "Greeting", 'author': 'alibaba'}
     store.set('hello', (data, metadata))
@@ -183,7 +183,7 @@ Transactions are re-entrant, so it is safe to do the following::
         with store.transaction('Adding keypair'):
             store.set(keypair.key1, (keypair.data1, keypair.metadata1))
             store.set(keypair.key2, (keypair.data2, keypair.metadata2))
-    
+
     def add_many_keypairs(keypairs):
         with store.transaction('Adding many keypairs'):
             for keypair in keypairs:
@@ -208,4 +208,3 @@ Events
 The various stores use the Encore event system, which is why the stores must
 be supplied with a reference to an EventManager instance.  The events which are
 emitted are referenced in the documentation for each method.
-

--- a/encore/concurrent/futures/enhanced_thread_pool_executor.py
+++ b/encore/concurrent/futures/enhanced_thread_pool_executor.py
@@ -31,13 +31,12 @@ in future implementations of concurrent.futures.thread.
 
 """
 
-from __future__ import with_statement
 import atexit
 import itertools
+import queue
 import threading
 import weakref
 import time
-import Queue as queue
 
 from concurrent.futures import _base
 

--- a/encore/concurrent/futures/tests/test_asynchronizer.py
+++ b/encore/concurrent/futures/tests/test_asynchronizer.py
@@ -140,7 +140,7 @@ class TestAsynchronizer(unittest.TestCase):
         """
         logger_name = 'encore.concurrent.futures.abc_work_scheduler'
         with loghandler(logger_name) as handler:
-            self.asynchronizer.submit(operator.div, 1, 0)
+            self.asynchronizer.submit(operator.truediv, 1, 0)
             self.asynchronizer.wait()
 
         # We log two messages for each failure. The actual traceback
@@ -172,7 +172,7 @@ class TestAsynchronizer(unittest.TestCase):
         # Submit a bad job
         logger_name = 'encore.concurrent.futures.abc_work_scheduler'
         with loghandler(logger_name) as handler:
-            asynchronizer.submit(operator.div, 1, 0)
+            asynchronizer.submit(operator.truediv, 1, 0)
             asynchronizer.wait()
 
         # We log two messages for each failure. The actual traceback
@@ -219,7 +219,7 @@ class TestAsynchronizer(unittest.TestCase):
 
         # Submit a bad job
         with loghandler(logger_name) as handler:
-            asynchronizer.submit(operator.div, 1, 0)
+            asynchronizer.submit(operator.truediv, 1, 0)
             asynchronizer.wait()
 
         # We log two messages for each failure. The actual traceback

--- a/encore/concurrent/futures/tests/test_enhanced_thread_pool_executor.py
+++ b/encore/concurrent/futures/tests/test_enhanced_thread_pool_executor.py
@@ -131,7 +131,7 @@ class EnhancedThreadPoolShutdownTest(EnhancedThreadPoolMixin, unittest.TestCase)
             import sys
             def sleep_and_print(t, msg):
                 sleep(t)
-                print msg
+                print(msg)
                 sys.stdout.flush()
             t = {executor_type}(5)
             t.submit(sleep_and_print, 1.0, "apple")
@@ -327,9 +327,9 @@ class EnhancedThreadPoolExecutorTest(EnhancedThreadPoolMixin, unittest.TestCase)
 
     def test_map_exception(self):
         i = self.executor.map(divmod, [1, 1, 1, 1], [2, 3, 0, 5])
-        self.assertEqual(i.next(), (0, 1))
-        self.assertEqual(i.next(), (0, 1))
-        self.assertRaises(ZeroDivisionError, i.next)
+        self.assertEqual(next(i), (0, 1))
+        self.assertEqual(next(i), (0, 1))
+        self.assertRaises(ZeroDivisionError, next, i)
 
     def test_map_timeout(self):
         results = []
@@ -372,7 +372,7 @@ class EnhancedThreadPoolExecutorTest(EnhancedThreadPoolMixin, unittest.TestCase)
         executor = EnhancedThreadPoolExecutor(max_workers=5)
         with executor as e:
             # Start some threads.
-            for _ in xrange(10):
+            for _ in range(10):
                 e.submit(pow, 2, 2)
             expected_prefix = "{0}Worker-".format(type(e).__name__)
             for t in e._threads:
@@ -391,7 +391,7 @@ class EnhancedThreadPoolExecutorTest(EnhancedThreadPoolMixin, unittest.TestCase)
         with executor as e:
             self.assertEqual(e.name, "DeadParrotExecutioner")
             # Start some threads.
-            for _ in xrange(10):
+            for _ in range(10):
                 e.submit(pow, 2, 2)
             expected_prefix = "DeadParrotExecutionerWorker-"
             for t in e._threads:
@@ -469,11 +469,11 @@ class EnhancedThreadPoolWaitAtExit(unittest.TestCase):
 
     def test_no_wait_at_exit(self):
         rc, out, err = self._execute(False)
-        self.assertEqual(out, '')
+        self.assertEqual(out.decode("utf-8"), '')
 
     def test_wait_at_exit(self):
         rc, out, err = self._execute(True)
-        self.assertEqual(out, 'FINISHED')
+        self.assertEqual(out.decode("utf-8"), 'FINISHED')
 
 
 class TestCustomFuture(unittest.TestCase):

--- a/encore/concurrent/futures/tests/test_serializer.py
+++ b/encore/concurrent/futures/tests/test_serializer.py
@@ -137,7 +137,7 @@ class TestSerializer(unittest.TestCase):
         """
         logger_name = 'encore.concurrent.futures.abc_work_scheduler'
         with loghandler(logger_name) as handler:
-            self.serializer.submit(operator.div, 1, 0)
+            self.serializer.submit(operator.truediv, 1, 0)
             self.serializer.wait()
 
         # We log two messages for each failure. The actual traceback
@@ -169,7 +169,7 @@ class TestSerializer(unittest.TestCase):
         # Submit a bad job
         logger_name = 'encore.concurrent.futures.abc_work_scheduler'
         with loghandler(logger_name) as handler:
-            serializer.submit(operator.div, 1, 0)
+            serializer.submit(operator.truediv, 1, 0)
             serializer.wait()
 
         # We log two messages for each failure. The actual traceback
@@ -216,7 +216,7 @@ class TestSerializer(unittest.TestCase):
 
         # Submit a bad job
         with loghandler(logger_name) as handler:
-            serializer.submit(operator.div, 1, 0)
+            serializer.submit(operator.truediv, 1, 0)
             serializer.wait()
 
         # We log two messages for each failure. The actual traceback

--- a/encore/concurrent/futures/tests/test_serializing_asynchronizer.py
+++ b/encore/concurrent/futures/tests/test_serializing_asynchronizer.py
@@ -186,7 +186,7 @@ class TestSerializingAsynchronizer(unittest.TestCase):
         """
         logger_name = 'encore.concurrent.futures.abc_work_scheduler'
         with loghandler(logger_name) as handler:
-            self.asynchronizer.submit(operator.div, 1, 0)
+            self.asynchronizer.submit(operator.truediv, 1, 0)
             self.asynchronizer.wait()
 
         # We log two messages for each failure. The actual traceback
@@ -218,7 +218,7 @@ class TestSerializingAsynchronizer(unittest.TestCase):
         # Submit a bad job
         logger_name = 'encore.concurrent.futures.abc_work_scheduler'
         with loghandler(logger_name) as handler:
-            asynchronizer.submit(operator.div, 1, 0)
+            asynchronizer.submit(operator.truediv, 1, 0)
             asynchronizer.wait()
 
         # We log two messages for each failure. The actual traceback
@@ -265,7 +265,7 @@ class TestSerializingAsynchronizer(unittest.TestCase):
 
         # Submit a bad job
         with loghandler(logger_name) as handler:
-            asynchronizer.submit(operator.div, 1, 0)
+            asynchronizer.submit(operator.truediv, 1, 0)
             asynchronizer.wait()
 
         # We log two messages for each failure. The actual traceback

--- a/encore/events/heartbeat.py
+++ b/encore/events/heartbeat.py
@@ -13,10 +13,8 @@ import threading
 from .abstract_event_manager import BaseEvent
 from .package_globals import get_event_manager
 
-if sys.platform == 'win32':
-    accurate_time = time.clock
-else:
-    accurate_time = time.time
+accurate_time = time.monotonic
+
 
 class HeartbeatEvent(BaseEvent):
     """ Event which is emitted periodically
@@ -25,24 +23,24 @@ class HeartbeatEvent(BaseEvent):
 
 class Heartbeat(object):
     """ Service which emits an event periodically
-    
+
     Note that unless the event manager uses threaded dispatch, event listeners
     which take longer than the interval to perform will result in a slower
     heartbeat.  The heartbeat runs on its own thread, and as a result, any
     listeners will also run on that thread.
-    
+
     The heartbeat is only intended to be approximately accurate, and should not
     be used for applications which require precise timing.
-    
+
     """
-    
+
     def __init__(self, interval=1/50., event_manager=None):
         self.state = 'waiting'
         self.interval = interval
         self.frame_count = 0
         self.event_manager = (event_manager if event_manager is not None
             else get_event_manager())
-    
+
     def run(self):
         self.state = 'running'
         while self.state in ['running', 'paused']:
@@ -62,5 +60,3 @@ class Heartbeat(object):
         thread = threading.Thread(target=self.run)
         thread.daemon = True
         thread.start()
-    
-

--- a/encore/events/tests/test_event_manager.py
+++ b/encore/events/tests/test_event_manager.py
@@ -7,7 +7,7 @@
 
 # Standard library imports.
 import unittest
-import mock
+import unittest.mock as mock
 import weakref
 import threading
 
@@ -396,7 +396,7 @@ class TestEventManager(unittest.TestCase):
         evt = MyEvt()
         self.evt_mgr.connect(BaseEvent, callback)
         self.evt_mgr.emit(evt)
-        self.assertEqual(call_seq, range(3))
+        self.assertEqual(call_seq, [0, 1, 2])
 
     def test_reentrant_disconnect_emit(self):
         """ Test listener is called even if it is disconnected before notify.
@@ -649,7 +649,7 @@ class TracingTests(unittest.TestCase):
         """ Test whether vetoing of actions works. """
         callback1 = mock.Mock()
         callback2 = mock.Mock()
-        
+
         self.evt_mgr.set_trace(self.trace_func_veto)
         self.evt_mgr.connect(BaseEvent, callback1)
         self.evt_mgr.emit(BaseEvent())

--- a/encore/storage/file_lock.py
+++ b/encore/storage/file_lock.py
@@ -122,7 +122,7 @@ class FileLock(object):
                 else:
                     raise
             else:
-                os.write(fd, self._data)
+                os.write(fd, self._data.encode("utf-8"))
                 os.close(fd)
                 return True
             if 0 < self.timeout < time.time()-start_time:
@@ -141,7 +141,7 @@ class FileLock(object):
         """
         try:
             with open(self.full_path, 'rb') as f:
-                data = f.read()
+                data = f.read().decode("utf-8")
             if data != self._data:
                 raise LockError('Releasing an unacquired lock')
             else:
@@ -212,15 +212,15 @@ class FileLock(object):
                 time.sleep(self.poll_interval)
             else:
                 return True
-                
+
     def get_data(self):
         """Return the data stored in the lock file.
-        
+
         If None is returned the lock has not been acquired.
         """
         try:
             with open(self.full_path, 'rb') as f:
-                text = f.read()
+                text = f.read().decode("utf-8")
         except IOError:
             text = None
         return text

--- a/encore/storage/locking_filesystem_store.py
+++ b/encore/storage/locking_filesystem_store.py
@@ -321,7 +321,7 @@ class LockingFileSystemStore(FileSystemStore):
 
         """
         timestamp = since
-        if isinstance(timestamp, basestring):
+        if isinstance(timestamp, str):
             ISO_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
             timestamp = datetime.datetime.strptime(timestamp, ISO_FORMAT)
         timestamp -= self._max_time_delta

--- a/encore/storage/simple_auth_store.py
+++ b/encore/storage/simple_auth_store.py
@@ -517,31 +517,31 @@ class SimpleAuthStore(AbstractStore):
 
     def check_permissions(self, key=None):
         """ Return permissions that the user has for the provided key
-        
+
         The default behaviour gives all authenticated users full access to all
         keys.  Subclasses may implement finer-grained controls based on user
         groups or other permissioning systems.
-        
+
         Parameters
         ----------
         key : str or None
             The key which the permissions are being requested for, or the global
             permissions if the key is None.
-        
+
         Returns
         -------
         permissions : set
             A set of strings chosen from 'connect', 'exists', 'get', 'set', and/or
             'delete' which express the permissions that the user has on that
             particular key.
-        
+
         """
         if self._username:
             user_key = self.user_key_path + self._username
-            print user_key
+            print(user_key)
             try:
                 token = self.user_key_store.get_data(user_key).read()
-                print 'token', token
+                print('token', token)
             except KeyError:
                 return set()
             if self._token == token:

--- a/encore/storage/string_value.py
+++ b/encore/storage/string_value.py
@@ -5,15 +5,15 @@
 # This file is open source software distributed according to the terms in LICENSE.txt
 #
 
-from cStringIO import StringIO
+from io import StringIO
 import time
 
 from .abstract_store import Value, AuthorizationError
 
 class StringValue(Value):
-    
+
     def __init__(self, data='', metadata=None, created=None, modified=None):
-        if not isinstance(data, basestring):
+        if not isinstance(data, str):
             raise ValueError(data)
         self._data = data
         self._data_stream = None

--- a/encore/storage/tests/abstract_test.py
+++ b/encore/storage/tests/abstract_test.py
@@ -280,10 +280,10 @@ class AbstractStoreReadTest(TestCase):
         if self.store is None:
             self.skipTest('Abstract test case')
         self.utils_large()
-        #print list(self.store.query_keys())
-        #print list(self.store1.query_keys())
-        #print list(self.store2.query_keys())
-        #print list(self.store3.query_keys())
+        #print(list(self.store.query_keys()))
+        #print(list(self.store1.query_keys()))
+        #print(list(self.store2.query_keys()))
+        #print(list(self.store3.query_keys()))
         with temp_dir() as directory:
             filepath = os.path.join(directory, 'test')
             self.store.to_file('test3', filepath)

--- a/encore/storage/tests/static_url_store_test.py
+++ b/encore/storage/tests/static_url_store_test.py
@@ -12,9 +12,9 @@ from shutil import rmtree
 import json
 import time
 import urllib
-import SocketServer
-from BaseHTTPServer import HTTPServer
-from SimpleHTTPServer import SimpleHTTPRequestHandler
+import socketserver
+from http.server import HTTPServer
+from http.server import SimpleHTTPRequestHandler
 
 import encore.storage.tests.abstract_test as abstract_test
 from ..static_url_store import StaticURLStore
@@ -100,7 +100,7 @@ class StaticURLStoreReadTest(abstract_test.AbstractStoreReadTest):
         with file(os.path.join(self.path, filename), 'wb') as fp:
             fp.write(data)
 
-class ThreadedHTTPServer(SocketServer.ThreadingMixIn, HTTPServer):
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
     pass
 
 class StaticURLStoreHTTPReadTest(StaticURLStoreReadTest):

--- a/encore/storage/utils.py
+++ b/encore/storage/utils.py
@@ -30,19 +30,19 @@ class StoreProgressManager(ProgressManager):
     StartEventType = StoreProgressStartEvent
     StepEventType = StoreProgressStepEvent
     EndEventType = StoreProgressEndEvent
-    
+
 
 class DummyTransactionContext(object):
     """ A dummy class that can be returned by stores which don't support transactions
-    
+
     This class guarantees that there is only one transaction object for each
     store instance.
-    
+
     Parameters
     ----------
     store : key-value store instance
         The store that this transaction context is associated with.
-    
+
     """
     def __new__(cls, store):
         if getattr(store, '_transaction', None) is None:
@@ -50,10 +50,10 @@ class DummyTransactionContext(object):
             obj.store = store
             store._transaction = obj
         return store._transaction
-    
+
     def __enter__(self):
         return self
-    
+
     def __exit__(self, exc_type, exc_value, exc_traceback):
         return False
 
@@ -65,17 +65,17 @@ class SimpleTransactionContext(object):
     terms of nesting and event generation.  Subclasses should override the
     start, commit and rollback methods to perform appropriate implementation-specific
     actions.
-    
+
     This class correctly handles nested transactions by ensuring that each store
     has precisely one active transaction context and by tracking the number of
     times the context has been entered and exited.  The transaction is only
     committed once the top-level context has exited.
-    
+
     Parameters
     ----------
     store : key-value store instance
         The store that this transaction context is associated with.
-    
+
     """
     def __new__(cls, store):
         if getattr(store, '_transaction', None) is None:
@@ -85,21 +85,21 @@ class SimpleTransactionContext(object):
             obj._events = []
             store._transaction = obj
         return store._transaction
-    
+
     def __enter__(self):
         self._context_depth += 1
         if self._context_depth == 1:
             self.begin()
             self.store.event_manager.emit(StoreTransactionStartEvent(
-                source=self.store))    
+                source=self.store))
             # grab Set & veto events for later emission
             self.store.event_manager.connect(StoreModificationEvent, self._handle_event,
                 {'source': self.store}, sys.maxint)
-        
+
     def _handle_event(self, event):
         self._events.append(event)
         event.mark_as_handled()
-    
+
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self._context_depth -= 1
         if self._context_depth <= 0:
@@ -123,23 +123,23 @@ class SimpleTransactionContext(object):
 
     def begin(self):
         """ Begin a transaction
-        
+
         By default, this calls the store's ``_begin_transaction`` method.
         Override in subclasses if you need different behaviour.
         """
         getattr(self.store, '_begin_transaction', lambda: None)()
-    
+
     def commit(self):
         """ Commit a transaction
-        
+
         By default, this calls the store's ``_commit_transaction`` method.
         Override in subclasses if you need different behaviour.
         """
         getattr(self.store, '_commit_transaction', lambda: None)()
-    
+
     def rollback(self):
         """ Roll back a transaction
-        
+
         By default, this calls the store's ``_rollback_transaction`` method.
         Override in subclasses if you need different behaviour.
         """
@@ -148,54 +148,54 @@ class SimpleTransactionContext(object):
 
 class BufferIteratorIO(object):
     """ A file-like object based on an iterable of buffers
-    
+
     This takes an iterator of bytes objects, such as produced by the
     buffer_iterator function, and wraps it in a file-like interface which
     is usable with the store API.
-    
+
     This uses less memory than a StringIO, at the cost of some flexibility.
-    
+
     Parameters
     ----------
     iterator : iterator of bytes objects
         An iterator that produces a bytes object on each iteration.
-    
+
     """
-    
+
     def __init__(self, iterator):
         self.iterator = iterator
         self.buffer = b''
-    
+
     def read(self, buffer_size=1048576):
         """Read at most buffer_size bytes, returned as a string.
 
         """
         while len(self.buffer) < buffer_size:
             try:
-                data = self.iterator.next()
+                data = next(self.iterator)
             except StopIteration:
                 break
             self.buffer += data
         result = self.buffer[:buffer_size]
         self.buffer = self.buffer[buffer_size:]
         return result
-    
+
     def close(self):
         self.iterator = None
-    
+
     def __enter__(self):
         return self
-    
+
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.close()
 
 
 def buffer_iterator(filelike, buffer_size=1048576, progress=None):
     """ Return an iterator of byte buffers
-    
+
     The buffers of bytes default to the provided buffer_size.  This is a useful
     method when copying one data stream to another.
-    
+
     Parameters
     ----------
     filelike : a file-like object
@@ -207,7 +207,7 @@ def buffer_iterator(filelike, buffer_size=1048576, progress=None):
         inside a ``with`` block would be appropriate, but anthing that takes a
         `step` parameter which is the total number of bytes read so far will
         work.
-    
+
     """
     progress = progress if progress is not None else lambda *args, **kwargs: None
     bytes_iterated = 0
@@ -222,12 +222,12 @@ def buffer_iterator(filelike, buffer_size=1048576, progress=None):
 
 def tee(filelike, n=2, buffer_size=1048576):
     """ Clone a filelike stream into n parallel streams
-    
+
     This uses itertools.tee and buffer iterators, with the corresponding
     cautions about memory usage.  In general it should be more memory efficient
     than pulling everything into memory.
-    
-    
+
+
     Parameters
     ----------
     filelike : a file-like object
@@ -240,28 +240,28 @@ def tee(filelike, n=2, buffer_size=1048576):
     """
     iters = itertools.tee(buffer_iterator(filelike, buffer_size), n)
     return [BufferIteratorIO(iter) for iter in iters]
-    
+
 
 class hashing_file(object):
     """ File-like wrapper which produces a hash as it is read
-    
+
     """
     def __init__(self, filelike, hash):
         self.filelike = filelike
         self.hash = hash
         self.len = 0
-    
+
     def read(self, nbytes):
         data = self.filelike.read(nbytes)
         self.hash.update(data)
         self.len += len(data)
         return data
-    
+
     def close(self):
         return self.filelike.close()
-    
+
     def __enter__(self):
         return self
-    
+
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.filelike.close()

--- a/examples/storage/todo_list.py
+++ b/examples/storage/todo_list.py
@@ -24,27 +24,27 @@ from encore.storage.string_value import StringValue
 
 class ToDoList(object):
     """ To-do list class
-    
+
     This is a to-do list which stores its data in an encore.storage store.
     Any writeable store can be used for this (and a read-only store can even
     be used if it is pre-filled with appropriate data).
-    
+
     Attributes
     ----------
     store : AbstractStore instance
         The store which holds the information.
-    
+
     """
-    
+
     def __init__(self, store=None):
         if store is None:
             store = DictMemoryStore()
         self.store = store
         self.store.connect()
-        
+
     def add_todo(self, who, what, where, when):
         """ Add an item to the to-do list
-        
+
         Parameters
         ----------
         who : string
@@ -55,7 +55,7 @@ class ToDoList(object):
             The location of the item
         when : datetime
             The time when the item will occur
-        
+
         """
         metadata = {
             'who': who,
@@ -73,31 +73,31 @@ class ToDoList(object):
         key = when.isoformat()+'-'+who
         self.store.set(key, value)
         return key
-    
+
     def remove_todo(self, when, who):
         """ Remove an item to the to-do list
-        
+
         Parameters
         ----------
         when : datetime
             The time when the item to be removed occurs.
         who : str
             The person involved in the datetime to be removed.
-        
+
         """
         keys = self.model.store.query_keys(year=when.year, month=when.month,
             day=when.day, hour=when.hour, minute=when.minute, second=when.second, who=who)
         for key in keys:
             self.store.delete(key)
-    
+
     def todo_for_date(self, date):
         """ Return the list of items for a given date
-        
+
         Parameters
         ----------
         date : datetime.date
             The date to be shown.
-        
+
         """
         items = self.store.query(year=date.year, month=date.month, day=date.day)
         return sorted((self.store.get(key) for key, metadata in items),
@@ -106,10 +106,10 @@ class ToDoList(object):
 
 class ToDoView(object):
     """ To-do view class
-    
+
     This is a class which provides a simple shell-based interface to the
     ToDoList class.
-    
+
     Attributes
     ----------
     model : ToDoList instance
@@ -118,16 +118,16 @@ class ToDoView(object):
         A format string suitable for printing a time using strftime.
     date_format : str
         A format string suitable for printing a date using strftime.
-    
+
     """
-    
+
     def __init__(self, model=None, time_format='%I:%M %p', date_format='%d/%m/%y'):
         if model is None:
             model = ToDoList()
         self.model = model
         self.time_format = time_format
         self.date_format = date_format
-    
+
     def show_summary(self, value, show_date=False):
         """ Display an item's summary """
         metadata = value.metadata
@@ -138,14 +138,14 @@ class ToDoView(object):
             time_str = ''
         time = datetime.time(*metadata['time'])
         time_str += time.strftime(self.time_format)
-        print '{0} - {who} @ {where}'.format(time_str, **metadata)
+        print('{0} - {who} @ {where}'.format(time_str, **metadata))
         what = value.data.read(73)
         if '\n' in what:
             what = what.split('\n')[0]+'...'
         elif len(what) == 73:
             what = what[:72]+'...'
-        print '   {0}'.format(what)
-    
+        print('   {0}'.format(what))
+
     def show_item(self, value, show_date=False):
         """ Display an item's full information """
         metadata = value.metadata
@@ -156,21 +156,21 @@ class ToDoView(object):
             time_str = ''
         time = datetime.time(*metadata['time'])
         time_str += time.strftime(self.time_format)
-        print '''Time:  {0}
+        print('''Time:  {0}
 Who:   {who}
 Where: {where}
-'''.format(time_str, **metadata)
+'''.format(time_str, **metadata))
         for chunk in value.iterdata():
             sys.stdout.write(chunk)
-    
+
     def show_day(self, date=None):
         """ Display all items in a day """
         if date is None:
             date = datetime.date.today()
-        print date.strftime(self.date_format)
+        print(date.strftime(self.date_format))
         for value in self.model.todo_for_date(date):
             self.show_summary(value)
-    
+
     def add_todo(self, date=None, time=None, who=None, where=None):
         """ Add an item to the to-do list"""
         if date is None:
@@ -184,7 +184,7 @@ Where: {where}
             where = raw_input('Where: ')
         what = sys.stdin.read()
         self.model.add_todo(who, what, where, when)
-    
+
     def remove_todo(self, date=None, time=None, who=None):
         """ Remove an item to the to-do list"""
         if date is None:
@@ -194,4 +194,3 @@ Where: {where}
         if who is None:
             who = raw_input('Who:   ')
         self.model.remove_todo(datetime.datetime.combine(date, time), who)
-        

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,11 @@
 # All rights reserved.
 
 import os.path
+import runpy
+
 from setuptools import setup, find_packages
 
-d = {}
-execfile(os.path.join('encore', '__init__.py'), d)
+d = runpy.run_path(os.path.join('encore', '__init__.py'))
 
 setup(
     name='encore',


### PR DESCRIPTION
This PR attempts to bring Encore kicking and screaming into the century of Python 3.

The changes in this PR are sufficient to get a unittest run passing on my machine under Python 3.6, but there are still failures with nosetests.

I believe the failures are confined to the `encore.storage` subpackage. The shallow issue is that we're using `cStringIO`, which no longer exists. However, there isn't a straightforward mechanical translation here: we need to figure out where `StringIO` should be replaced with `BytesIO` and where it should be left as `StringIO`. That requires more of an understanding of what that code is intended to do than I have at present.