### PR TITLE
Remove Python 2-isms, add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -1,0 +1,31 @@
+name: Test with pip
+
+on:
+- pull_request
+- workflow_dispatch
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.6', '3.8', '3.10']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Get encore source
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies and local packages
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+    - name: Run tests
+      run: |
+        mkdir testdir
+        cd testdir
+        python -m unittest discover -v encore

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.5
 install:
   - pip install -U nose
-  - pip install coverage coveralls requests futures sphinx six
+  - pip install coverage coveralls requests sphinx
   - python setup.py develop
 before_script:
   - mkdir testrunner

--- a/docs/source/concurrent/index.rst
+++ b/docs/source/concurrent/index.rst
@@ -6,8 +6,8 @@ The :py:mod:`encore.concurrent` module provides utilities and libraries to
 assist with threaded and other parallel code.
 
 The :py:mod:`encore.concurrent.futures` subpackage provides an enhanced
-version of the ``concurrent.futures`` package for Python 2.7 with some
-useful experimental additions.
+version of the ``concurrent.futures`` package from the standard library
+with some useful experimental additions.
 
 The :py:mod:`encore.concurrent.threadtools` module provides some utilities
 that encapsulate useful patterns in threaded code.

--- a/encore/concurrent/futures/enhanced_thread_pool_executor.py
+++ b/encore/concurrent/futures/enhanced_thread_pool_executor.py
@@ -32,13 +32,12 @@ in future implementations of concurrent.futures.thread.
 
 """
 
-from __future__ import with_statement
 import atexit
 import itertools
+import queue
 import threading
 import weakref
 import time
-from six.moves import queue
 
 from concurrent.futures import _base
 
@@ -238,9 +237,9 @@ class EnhancedThreadPoolExecutor(_base.Executor):
         Raises:
             TimeoutError: If the entire result iterator could not be generated
                 before the given timeout.
-                
+
             Exception: If fn(\*args) raises for any values.
-            
+
         """
         timeout = kwargs.get('timeout')
         if timeout is not None:

--- a/encore/concurrent/futures/tests/test_enhanced_thread_pool_executor.py
+++ b/encore/concurrent/futures/tests/test_enhanced_thread_pool_executor.py
@@ -7,8 +7,6 @@ import time
 import unittest
 import weakref
 
-from six.moves import xrange
-
 from concurrent import futures
 from concurrent.futures._base import (
     PENDING, RUNNING, CANCELLED, CANCELLED_AND_NOTIFIED, FINISHED, Future)
@@ -124,7 +122,7 @@ class EnhancedThreadPoolShutdownTest(EnhancedThreadPoolMixin, unittest.TestCase)
 
     def test_interpreter_shutdown(self):
         # Test the atexit hook for shutdown of worker threads and processes
-        rc, out, err = assert_python_ok('-c', """from __future__ import print_function
+        rc, out, err = assert_python_ok('-c', """\
 if 1:
     from encore.concurrent.futures.enhanced_thread_pool_executor import EnhancedThreadPoolExecutor
     from time import sleep
@@ -373,7 +371,7 @@ class EnhancedThreadPoolExecutorTest(EnhancedThreadPoolMixin, unittest.TestCase)
         executor = EnhancedThreadPoolExecutor(max_workers=5)
         with executor as e:
             # Start some threads.
-            for _ in xrange(10):
+            for _ in range(10):
                 e.submit(pow, 2, 2)
             expected_prefix = "{0}Worker-".format(type(e).__name__)
             for t in e._threads:
@@ -392,7 +390,7 @@ class EnhancedThreadPoolExecutorTest(EnhancedThreadPoolMixin, unittest.TestCase)
         with executor as e:
             self.assertEqual(e.name, "DeadParrotExecutioner")
             # Start some threads.
-            for _ in xrange(10):
+            for _ in range(10):
                 e.submit(pow, 2, 2)
             expected_prefix = "DeadParrotExecutionerWorker-"
             for t in e._threads:

--- a/encore/events/tests/test_event_manager.py
+++ b/encore/events/tests/test_event_manager.py
@@ -7,7 +7,7 @@
 
 # Standard library imports.
 import unittest
-import mock
+import unittest.mock as mock
 import weakref
 import threading
 
@@ -653,7 +653,7 @@ class TracingTests(unittest.TestCase):
         """ Test whether vetoing of actions works. """
         callback1 = mock.Mock()
         callback2 = mock.Mock()
-        
+
         self.evt_mgr.set_trace(self.trace_func_veto)
         self.evt_mgr.connect(BaseEvent, callback1)
         self.evt_mgr.emit(BaseEvent())

--- a/encore/storage/abstract_store.py
+++ b/encore/storage/abstract_store.py
@@ -22,9 +22,8 @@ data values can be stored in the key-value store.
 """
 
 from abc import ABCMeta, abstractmethod, abstractproperty
-from six.moves import zip as izip
 import fnmatch
-from six import BytesIO
+from io import BytesIO
 import warnings
 
 from encore.events.api import get_event_manager
@@ -843,7 +842,7 @@ class AbstractStore(AbstractReadOnlyStore):
 
         """
         with self.transaction('Setting '+', '.join('"%s"' % key for key in keys)):
-            for key, value in izip(keys, values):
+            for key, value in zip(keys, values):
                 self.set(key, value, buffer_size)
 
 
@@ -886,7 +885,7 @@ class AbstractStore(AbstractReadOnlyStore):
 
         """
         with self.transaction('Setting data for '+', '.join('"%s"' % key for key in keys)):
-            for key, data in izip(keys, datas):
+            for key, data in zip(keys, datas):
                 self.set_data(key, data, buffer_size)
 
 
@@ -916,7 +915,7 @@ class AbstractStore(AbstractReadOnlyStore):
 
         """
         with self.transaction('Setting metadata for '+', '.join('"%s"' % key for key in keys)):
-            for key, metadata in izip(keys, metadatas):
+            for key, metadata in zip(keys, metadatas):
                 self.set_metadata(key, metadata)
 
 
@@ -946,7 +945,7 @@ class AbstractStore(AbstractReadOnlyStore):
 
         """
         with self.transaction('Updating metadata for '+', '.join('"%s"' % key for key in keys)):
-            for key, metadata in izip(keys, metadatas):
+            for key, metadata in zip(keys, metadatas):
                 self.update_metadata(key, metadata)
 
 

--- a/encore/storage/dynamic_url_store.py
+++ b/encore/storage/dynamic_url_store.py
@@ -22,7 +22,7 @@ HTTP operations.
 from email.utils import parsedate_tz, mktime_tz
 import json
 
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 import requests
 

--- a/encore/storage/locking_filesystem_store.py
+++ b/encore/storage/locking_filesystem_store.py
@@ -36,8 +36,6 @@ import os
 import time
 import threading
 
-from six import string_types
-
 # ETS library imports.
 from .events import StoreSetEvent, StoreUpdateEvent,\
     StoreDeleteEvent, StoreKeyEvent
@@ -50,7 +48,7 @@ def transact(function, on_commit=True):
     """ Wrap a store method to add command to transaction instead of executing
     it immediately if within a transaction context. If not in a transaction
     context, the command is executed immediately.
-    
+
     Parameters
     ----------
     function - callable
@@ -157,12 +155,12 @@ class LockingFileSystemStore(FileSystemStore):
                  magic_fname='.FSStore',
                  remote_event_poll_interval=5.0,
                  max_time_delta=datetime.timedelta(minutes=1)):
-        """Initializes the store given a path to a store. 
-        
+        """Initializes the store given a path to a store.
+
         Parameters
-        ----------        
+        ----------
         event_manager : Event Manager instance
-            This is used to emit suitable events.        
+            This is used to emit suitable events.
         path : str:
             A path to the root of the file system store.
         force_lock_timeout: float
@@ -177,7 +175,7 @@ class LockingFileSystemStore(FileSystemStore):
             The maximum permissible timedelta between different clients.
             This value is used to return the keys in a query_key when the
             parameters are ``last_modified__gte=timedelta`` , in this case the
-            max_time_delta is subtracted from the given query timedelta. 
+            max_time_delta is subtracted from the given query timedelta.
 
         """
         super(LockingFileSystemStore, self).__init__(path, magic_fname)
@@ -231,17 +229,17 @@ class LockingFileSystemStore(FileSystemStore):
 
     def query(self, select=None, **kwargs):
         """ Query for keys and metadata matching metadata provided as keyword arguments
-        
+
         This provides a very simple querying interface that returns precise
         matches with the metadata.  If no arguments are supplied, the query
         will return the complete set of metadata for the key-value store.
-        
+
         Parameters
         ----------
         select : iterable of strings or None
             An optional list of metadata keys to return.  If this is not None,
             then the metadata dictionaries will only have values for the specified
-            keys populated.        
+            keys populated.
         kwargs :
             Arguments where the keywords are metadata keys, and values are
             possible values for that metadata item.
@@ -253,7 +251,7 @@ class LockingFileSystemStore(FileSystemStore):
             all the specified values for the specified metadata keywords.
             If a key specified in select is not present in the metadata of a
             particular key, then it will not be present in the returned value.
-        
+
         """
         all_metadata = glob.glob(os.path.join(self._root, '*.metadata'))
         items = [(os.path.splitext(os.path.basename(x))[0], x) for x in all_metadata]
@@ -270,17 +268,17 @@ class LockingFileSystemStore(FileSystemStore):
                 metadata = self._get_metadata(path)
                 if all(metadata.get(arg) == value for arg, value in kwargs.items()):
                     yield key, metadata.copy()
-    
+
     def query_keys(self, **kwargs):
         """ Query for keys matching metadata provided as keyword arguments
-        
+
         This provides a very simple querying interface that returns precise
         matches with the metadata.  If no arguments are supplied, the query
         will return the complete set of keys for the key-value store.
-        
+
         This is equivalent to ``self.query(**kwargs).keys()``, but potentially
         more efficiently implemented.
-        
+
         Parameters
         ----------
         kwargs :
@@ -292,7 +290,7 @@ class LockingFileSystemStore(FileSystemStore):
         result : iterable
             An iterable of key-value store keys whose metadata matches all the
             specified values for the specified metadata keywords.
-        
+
         """
         # Optimize for special cases.
         basename = os.path.basename
@@ -324,7 +322,7 @@ class LockingFileSystemStore(FileSystemStore):
 
         """
         timestamp = since
-        if isinstance(timestamp, string_types):
+        if isinstance(timestamp, str):
             ISO_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
             timestamp = datetime.datetime.strptime(timestamp, ISO_FORMAT)
         timestamp -= self._max_time_delta
@@ -534,4 +532,3 @@ class LockingFileSystemStore(FileSystemStore):
 
     def __del__(self):
         self._remote_poll_thread = None
-

--- a/encore/storage/sqlite_store.py
+++ b/encore/storage/sqlite_store.py
@@ -22,9 +22,8 @@ This class is provided in part as a sample implementation of the API.
 import sqlite3
 import time
 
-import six
-from six import BytesIO
-from six.moves import cPickle
+from io import BytesIO
+import pickle
 
 from .abstract_store import AbstractStore
 from .string_value import StringValue
@@ -34,19 +33,15 @@ from .utils import (
     add_context_manager_support
 )
 
-if six.PY3:
-    buffer = sqlite3.Binary
+buffer = sqlite3.Binary
 
 
 def adapt_dict(d):
-    return buffer(cPickle.dumps(d, protocol=2))
+    return buffer(pickle.dumps(d, protocol=2))
 
 
 def convert_dict(s):
-    if six.PY3:
-        return cPickle.loads(s, encoding='ascii')
-    else:
-        return cPickle.loads(s)
+    return pickle.loads(s, encoding='ascii')
 
 sqlite3.register_adapter(dict, adapt_dict)
 sqlite3.register_converter('dict', convert_dict)
@@ -481,7 +476,7 @@ class SqliteStore(AbstractStore):
                     ' and '.join('"'+column+'"=?' for column in columns))
             else:
                 query = 'select key, metadata from "%s"' % (self.table,)
-            rows = self._connection.execute(query, [buffer(cPickle.dumps(kwargs[column], protocol=2))
+            rows = self._connection.execute(query, [buffer(pickle.dumps(kwargs[column], protocol=2))
                 for column in columns])
         else:
             unindexed_columns = set(kwargs)
@@ -537,7 +532,7 @@ class SqliteStore(AbstractStore):
                         ' and '.join('"'+column+'"=?' for column in columns))
                 else:
                     query = 'select key from "%s"' % (self.table,)
-            rows = self._connection.execute(query, [buffer(cPickle.dumps(kwargs[column], protocol=2))
+            rows = self._connection.execute(query, [buffer(pickle.dumps(kwargs[column], protocol=2))
                 for column in columns])
         else:
             unindexed_columns = set(kwargs)
@@ -694,7 +689,7 @@ class SqliteStore(AbstractStore):
             self.index_columns |= missing_columns
 
         columns = [column for column in metadata if column in self.index_columns]
-        values = [buffer(cPickle.dumps(metadata[column], protocol=2)) for column in columns]
+        values = [buffer(pickle.dumps(metadata[column], protocol=2)) for column in columns]
         if columns:
             self._update_columns(key, columns, values)
 

--- a/encore/storage/static_url_store.py
+++ b/encore/storage/static_url_store.py
@@ -28,7 +28,7 @@ A typical static server might be layed out as::
 
 import threading
 import json
-from six.moves import urllib
+import urllib
 import time
 
 from .abstract_store import AbstractReadOnlyStore
@@ -39,10 +39,10 @@ from .utils import add_context_manager_support
 
 def basic_auth_factory(**kwargs):
     """ A factory that creates a :py:class:`~.HTTPBasicAuthHandler` instance
-    
+
     The arguments are passed directly through to the :py:meth:`add_password`
     method of the handler.
-    
+
     """
     auth_handler = urllib.request.HTTPBasicAuthHandler()
     auth_handler.add_password(**kwargs)
@@ -50,40 +50,40 @@ def basic_auth_factory(**kwargs):
 
 class StaticURLStore(AbstractReadOnlyStore):
     """ A read-only key-value store that is a front end for data served via URLs
-    
+
     All data is assumed to be served from some root url.  In addition
-    the store requires knowledge of two paths: a data prefix URL which is a 
+    the store requires knowledge of two paths: a data prefix URL which is a
     partial URL to which the keys will be appended when requesting data, and a
     query URL which is a single URL which provides all metadata as a json
     encoded file.
-    
+
     For example, an HTTP server may store data at URLs of the form::
-    
+
         http://www.example.com/data/<key>
-    
+
     and may store the metadata at::
-    
+
         http://www.example.com/index.json
-    
+
     These would have a root url of "http://www.example.com/", a data path
     of "data/" and a query path of "index.json".
-    
+
     All queries are performed using urllib.urlopen, so this store can be
     implemented by an HTTP, FTP or file server which serves static files.  When
     connecting, if appropriate credentials are supplied then HTTP authentication
     will be used when connecting the remote server
-   
+
     .. warning::
-    
+
         Since we use urllib without any further modifications, HTTPS requests
         do not validate the server's certificate.
-    
+
     Because of the limited nature of the interface, this store implementation
     is read only, and handles updates via periodic polling of the query prefix
     URL.  This guarantees that the viewed data is always consistent, it just may
     not be current. Most of the work of querying is done on the client side
     using the cached metadata.
-     
+
     Parameters
     ----------
     event_manager :
@@ -97,8 +97,8 @@ class StaticURLStore(AbstractReadOnlyStore):
         The URL that the metadata is served from.
     poll : float
         The polling frequency for the polling thread.  Polls every 5 min by default.
-    
-        
+
+
     """
     def __init__(self, root_url, data_path, query_path, poll=300):
         super(StaticURLStore, self).__init__()
@@ -106,18 +106,18 @@ class StaticURLStore(AbstractReadOnlyStore):
         self.data_path = data_path
         self.query_path = query_path
         self.poll = poll
-        
+
         self._opener = None
         self._index = None
         self._index_lock = threading.Lock()
         self._index_thread = None
 
-                
+
     def connect(self, credentials=None, proxy_handler=None, auth_handler_factory=None):
         """ Connect to the key-value store, optionally with authentication
-        
+
         This method creates appropriate urllib openers for the store.
-        
+
         Parameters
         ----------
         credentials : dict
@@ -133,7 +133,7 @@ class StaticURLStore(AbstractReadOnlyStore):
             An optional factory to build urllib authenticators.  The credentials
             will be passed as keyword arguments to this handler's add_password
             method.
-            
+
         """
         if credentials is not None:
             if auth_handler_factory is None:
@@ -151,19 +151,19 @@ class StaticURLStore(AbstractReadOnlyStore):
                 self._opener = urllib.request.build_opener()
             else:
                 self._opener = urllib.request.build_opener(auth_handler)
-        
+
         self.update_index()
         if self.poll > 0:
             self._index_thread = threading.Thread(target=self._poll)
             self._index_thread.start()
 
-        
+
     def disconnect(self):
         """ Disconnect from the key-value store
-        
+
         This method disposes or disconnects to any long-lived resources that the
         store requires.
-        
+
         """
 
         if self._index_thread is not None:
@@ -174,7 +174,7 @@ class StaticURLStore(AbstractReadOnlyStore):
 
     def is_connected(self):
         """ Whether or not the store is currently connected
-        
+
         Returns
         -------
         connected : bool
@@ -183,10 +183,10 @@ class StaticURLStore(AbstractReadOnlyStore):
         """
         return self._opener is not None
 
-    
+
     def info(self):
         """ Get information about the key-value store
-        
+
         Returns
         -------
         metadata : dict
@@ -196,21 +196,21 @@ class StaticURLStore(AbstractReadOnlyStore):
             'readonly': True
         }
 
-        
+
     ##########################################################################
     # Basic Create/Read/Update/Delete Methods
     ##########################################################################
-    
-    
+
+
     def get(self, key):
         """ Retrieve a stream of data and metdata from a given key in the key-value store.
-        
+
         Parameters
         ----------
         key : string
             The key for the resource in the key-value store.  They key is a unique
             identifier for the resource within the key-value store.
-        
+
         Returns
         -------
         data : file-like
@@ -219,7 +219,7 @@ class StaticURLStore(AbstractReadOnlyStore):
             by urllib's urlopen function.
         metadata : dictionary
             A dictionary of metadata for the key.
-        
+
         Raises
         ------
         KeyError :
@@ -231,16 +231,16 @@ class StaticURLStore(AbstractReadOnlyStore):
             metadata = self._index[key].copy()
         return URLValue(url, metadata, self._opener)
 
-    
+
     def get_data(self, key):
         """ Retrieve a stream from a given key in the key-value store.
-        
+
         Parameters
         ----------
         key : string
             The key for the resource in the key-value store.  They key is a unique
             identifier for the resource within the key-value store.
-        
+
         Returns
         -------
         data : file-like
@@ -264,7 +264,7 @@ class StaticURLStore(AbstractReadOnlyStore):
 
     def get_metadata(self, key, select=None):
         """ Retrieve the metadata for a given key in the key-value store.
-        
+
         Parameters
         ----------
         key : string
@@ -273,7 +273,7 @@ class StaticURLStore(AbstractReadOnlyStore):
         select : iterable of strings or None
             Which metadata keys to populate in the result.  If unspecified, then
             return the entire metadata dictionary.
-        
+
         Returns
         -------
         metadata : dict
@@ -281,7 +281,7 @@ class StaticURLStore(AbstractReadOnlyStore):
             has keys as specified by the select argument.  If a key specified in
             select is not present in the metadata, then it will not be present
             in the returned value.
-        
+
         Raises
         ------
         KeyError :
@@ -294,44 +294,44 @@ class StaticURLStore(AbstractReadOnlyStore):
             else:
                 metadata = self._index[key]
                 return dict((s, metadata[s]) for s in select if s in metadata)
-        
-                
+
+
     def exists(self, key):
         """ Test whether or not a key exists in the key-value store
-        
+
         Parameters
         ----------
         key : string
             The key for the resource in the key-value store.  They key is a unique
             identifier for the resource within the key-value store.
-        
+
         Returns
         -------
         exists : bool
             Whether or not the key exists in the key-value store.
-        
+
         """
         with self._index_lock:
             return key in self._index
 
-        
+
     ##########################################################################
     # Querying Methods
     ##########################################################################
-    
+
     def query(self, select=None, **kwargs):
         """ Query for keys and metadata matching metadata provided as keyword arguments
-        
+
         This provides a very simple querying interface that returns precise
         matches with the metadata.  If no arguments are supplied, the query
         will return the complete set of metadata for the key-value store.
-        
+
         Parameters
         ----------
         select : iterable of strings or None
             An optional list of metadata keys to return.  If this is not None,
             then the metadata dictionaries will only have values for the specified
-            keys populated.        
+            keys populated.
         kwargs :
             Arguments where the keywords are metadata keys, and values are
             possible values for that metadata item.
@@ -355,17 +355,17 @@ class StaticURLStore(AbstractReadOnlyStore):
                     if all(metadata.get(arg) == value for arg, value in kwargs.items()):
                         yield key, metadata.copy()
 
-    
+
     def query_keys(self, **kwargs):
         """ Query for keys matching metadata provided as keyword arguments
-        
+
         This provides a very simple querying interface that returns precise
         matches with the metadata.  If no arguments are supplied, the query
         will return the complete set of keys for the key-value store.
-        
+
         This is equivalent to ``self.query(**kwargs).keys()``, but potentially
         more efficiently implemented.
-        
+
         Parameters
         ----------
         kwargs :
@@ -377,30 +377,30 @@ class StaticURLStore(AbstractReadOnlyStore):
         result : iterable
             An iterable of key-value store keys whose metadata matches all the
             specified values for the specified metadata keywords.
-        
+
         """
         with self._index_lock:
             for key, metadata in self._index.items():
                 if all(metadata.get(arg) == value for arg, value in kwargs.items()):
                     yield key
 
-    
+
     ##########################################################################
     # Utility Methods
     ##########################################################################
 
     def update_index(self):
         """ Request the most recent version of the metadata
-        
+
         This downloads the json file at the query_path location, and updates
         the local metadata cache with this information.  It then emits events
         that represent the difference between the old metadata and the new
         metadata.
-        
+
         This method is normally called from the polling thread, but can be called
         by other code when needed.  It locks the metadata index whilst performing
         the update.
-        
+
         """
         url = self.root_url + self.query_path
         with self._index_lock:
@@ -424,11 +424,11 @@ class StaticURLStore(AbstractReadOnlyStore):
                 if old_index[key] != index[key]:
                     self.event_manager.emit(StoreUpdateEvent(self, key=key, metadata=index[key]))
 
-        
+
     ##########################################################################
     # Private Methods
     ##########################################################################
-    
+
     def _poll(self):
         t = time.time()
         while self._opener is not None:
@@ -437,4 +437,3 @@ class StaticURLStore(AbstractReadOnlyStore):
                 t = time.time()
             # tick
             time.sleep(0.5)
-

--- a/encore/storage/string_value.py
+++ b/encore/storage/string_value.py
@@ -5,7 +5,7 @@
 # This file is open source software distributed according to the terms in LICENSE.txt
 #
 
-from six import BytesIO
+from io import BytesIO
 import time
 
 from .abstract_store import Value, AuthorizationError

--- a/encore/storage/tests/abstract_test.py
+++ b/encore/storage/tests/abstract_test.py
@@ -12,7 +12,7 @@ from tempfile import mkdtemp
 import time
 from unittest import skip
 
-from six import BytesIO
+from io import BytesIO
 
 from ..utils import add_context_manager_support
 

--- a/encore/storage/tests/sqlite_store_test.py
+++ b/encore/storage/tests/sqlite_store_test.py
@@ -12,13 +12,10 @@ from tempfile import mkdtemp
 import time
 from unittest import TestCase
 
-import six
-
 from .abstract_test import StoreReadTestMixin, StoreWriteTestMixin
 from ..sqlite_store import SqliteStore
 
-if six.PY3:
-    buffer = sqlite3.Binary
+buffer = sqlite3.Binary
 
 class SqliteStoreReadTest(TestCase, StoreReadTestMixin):
 

--- a/encore/storage/tests/static_url_store_test.py
+++ b/encore/storage/tests/static_url_store_test.py
@@ -5,19 +5,16 @@
 # This file is open source software distributed according to the terms in LICENSE.txt
 #
 
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import itertools
 import json
 import os
 from shutil import rmtree
+import socketserver
 from tempfile import mkdtemp
 import threading
 from unittest import TestCase
-
-
-from six import itertools, next
-from six.moves import urllib
-from six.moves import socketserver as SocketServer
-from six.moves.BaseHTTPServer import HTTPServer
-from six.moves.SimpleHTTPServer import SimpleHTTPRequestHandler
+import urllib
 
 from .abstract_test import StoreReadTestMixin, StoreWriteTestMixin
 from ..static_url_store import StaticURLStore
@@ -111,7 +108,7 @@ class StaticURLStoreReadTest(TestCase, StoreReadTestMixin):
         with open(os.path.join(self.path, filename), 'wb') as fp:
             fp.write(data.encode('ascii'))
 
-class ThreadedHTTPServer(SocketServer.ThreadingMixIn, HTTPServer):
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
     pass
 
 class StaticURLStoreHTTPReadTest(StaticURLStoreReadTest):

--- a/encore/storage/url_value.py
+++ b/encore/storage/url_value.py
@@ -7,7 +7,7 @@
 
 from email.utils import parsedate_tz, mktime_tz
 
-from six.moves import urllib
+import urllib
 
 
 from .abstract_store import Value, AuthorizationError

--- a/encore/storage/utils.py
+++ b/encore/storage/utils.py
@@ -15,9 +15,7 @@ Utilities for key-value stores.
 
 import sys
 import itertools
-
-import six
-from six import create_bound_method
+from types import MethodType
 
 from encore.events.api import ProgressManager
 from .events import (StoreTransactionStartEvent, StoreTransactionEndEvent,
@@ -42,9 +40,9 @@ def add_context_manager_support(obj):
         pass
 
     if not hasattr(obj, '__enter__'):
-        obj.__enter__ = create_bound_method(__enter__, obj)
+        obj.__enter__ = MethodType(__enter__, obj)
     if not hasattr(obj, '__exit__'):
-        obj.__exit__ = create_bound_method(__exit__, obj)
+        obj.__exit__ = MethodType(__exit__, obj)
 
     return obj
 

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,10 @@
 
 import os.path
 from setuptools import setup, find_packages
-import sys
 
 encore_init = os.path.join('encore', '__init__.py')
-if sys.version_info.major == 3:
-    import runpy
-    d = runpy.run_path(encore_init)
-else:
-    d = {}
-    execfile(encore_init, d)
+import runpy
+d = runpy.run_path(encore_init)
 
 setup(
     name='encore',
@@ -24,4 +19,5 @@ setup(
     long_description=open('README.rst').read(),
     packages=find_packages(),
     requires=[],
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
This PR:
- adds a GitHub Actions-based test workflow
- fixes some Python 2-isms
- removes `six` and `futures` as dependencies (`futures` doesn't appear to be used anywhere in the current codebase)